### PR TITLE
Refactored the OpenUDID class to be UMS_OpenUDID.  This prevents conflic...

### DIFF
--- a/sdk/iOS_sdk/UMSAgent/OpenUDID.h
+++ b/sdk/iOS_sdk/UMSAgent/OpenUDID.h
@@ -48,7 +48,7 @@
 #define kOpenUDIDErrorOptedOut      1
 #define kOpenUDIDErrorCompromised   2
 
-@interface OpenUDID : NSObject {
+@interface UMS_OpenUDID : NSObject {
 }
 + (NSString*) value;
 + (NSString*) valueWithError:(NSError**)error;

--- a/sdk/iOS_sdk/UMSAgent/OpenUDID.m
+++ b/sdk/iOS_sdk/UMSAgent/OpenUDID.m
@@ -71,13 +71,13 @@ static NSString * const kOpenUDIDSlotPBPrefix = @"org.OpenUDID.slot.";
 static NSString * const kAppGUUID = @"app_guuid";
 static int const kOpenUDIDRedundancySlots = 100;
 
-@interface OpenUDID (Private)
+@interface UMS_OpenUDID (Private)
 + (void) _setDict:(id)dict forPasteboard:(id)pboard;
 + (NSMutableDictionary*) _getDictFromPasteboard:(id)pboard;
 + (NSString*) _getOpenUDID;
 @end
 
-@implementation OpenUDID
+@implementation UMS_OpenUDID
 
 // Archive a NSDictionary inside a pasteboard of a given type
 // Convenience method to support iOS & Mac OS X
@@ -170,7 +170,7 @@ static int const kOpenUDIDRedundancySlots = 100;
 // Otherwise, it will register the current app and return the OpenUDID
 //
 + (NSString*) value {
-    return [OpenUDID valueWithError:nil];
+    return [UMS_OpenUDID valueWithError:nil];
 }
 + (NSString*) valueWithError:(NSError **)error {
 
@@ -228,7 +228,7 @@ static int const kOpenUDIDRedundancySlots = 100;
             // assign availableSlotPBid to be the first one available
             if (availableSlotPBid==nil) availableSlotPBid = slotPBid;
         } else {
-            NSDictionary* dict = [OpenUDID _getDictFromPasteboard:slotPB];
+            NSDictionary* dict = [UMS_OpenUDID _getDictFromPasteboard:slotPB];
             NSString* oudid = [dict objectForKey:kOpenUDIDKey];
             OpenUDIDLog(@"SlotPB dict = %@",dict);
             if (oudid==nil) {
@@ -263,7 +263,7 @@ static int const kOpenUDIDRedundancySlots = 100;
             // this is the case where this app instance is likely to be the first one to use OpenUDID on this device
             // we create the OpenUDID, legacy or semi-random (i.e. most certainly unique)
             //
-            openUDID = [OpenUDID _getOpenUDID];
+            openUDID = [UMS_OpenUDID _getOpenUDID];
         } else {
             // or we leverage the OpenUDID shared by other apps that have already gone through the process
             // 
@@ -308,7 +308,7 @@ static int const kOpenUDIDRedundancySlots = 100;
         // Save the local dictionary to the corresponding UIPasteboard slot
         //
         if (openUDID && localDict)
-            [OpenUDID _setDict:localDict forPasteboard:slotPB];
+            [UMS_OpenUDID _setDict:localDict forPasteboard:slotPB];
     }
 
     // Save the dictionary locally if applicable

--- a/sdk/iOS_sdk/UMSAgent/UMSAgent/UMSAgent.m
+++ b/sdk/iOS_sdk/UMSAgent/UMSAgent/UMSAgent.m
@@ -132,7 +132,7 @@
     
     self.startDate = [[NSDate date] copy];
     NSString *currentTime = [[NSString alloc] initWithFormat:@"%f",[[NSDate date] timeIntervalSince1970]];
-    NSString *sessionIdentifier = [[NSString alloc] initWithFormat:@"%@%@", currentTime, [OpenUDID value]
+    NSString *sessionIdentifier = [[NSString alloc] initWithFormat:@"%@%@", currentTime, [UMS_OpenUDID value]
                                    ];
     self.sessionId = [self md5:sessionIdentifier];
     if(isLogEnabled)
@@ -811,7 +811,7 @@
     CGFloat scale = [[UIScreen mainScreen] scale];
     info.resolution = [[NSString alloc] initWithFormat:@"%.fx%.f",rect.size.width*scale,rect.size.height*scale];
     //Using open UDID 
-    info.deviceid = [OpenUDID value];
+    info.deviceid = [UMS_OpenUDID value];
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults]; 
     NSArray *languages = [defaults objectForKey:@"AppleLanguages"]; 
     info.language = [languages objectAtIndex:0];


### PR DESCRIPTION
Refactored the OpenUDID class to be UMS_OpenUDID.  This prevents conflicts for developers already using OpenUDID and including the libUMSAgent.a static library

From the OpenUDID github page:
"IMPORTANT: IF YOU ARE GOING TO INTEGRATE OpenUDID INSIDE A (STATIC) LIBRARY, PLEASE MAKE SURE YOU REFACTOR THE OpenUDID CLASS WITH A PREFIX OF YOUR OWN, E.G. ACME_OpenUDID. THIS WILL AVOID CONFUSION BY DEVELOPERS WHO ARE ALSO
USING OpenUDID IN THEIR OWN CODE."
