### PR TITLE
fix chart at /report/os

### DIFF
--- a/web/application/controllers/report/os.php
+++ b/web/application/controllers/report/os.php
@@ -76,7 +76,7 @@ class Os extends CI_Controller {
 	/*
 	 * Get os data by time phase, called by ajax
 	 */
-	function getOsData($timePhase) {
+	function getOsData() {
 		$productId = $this->common->getCurrentProduct ();
 		$fromTime = $this->common->getFromTime ();
 		$toTime = $this->common->getToTime ();


### PR DESCRIPTION
Navigating to /report/os creates an ajax request tor /report/os/getOsData

This was failing because the php was expecting an argument. The argument was not used in the getOsData method.
