### PR TITLE
show the most 10 version

### DIFF
--- a/web/application/models/product/versionmodel.php
+++ b/web/application/models/product/versionmodel.php
@@ -45,11 +45,12 @@ class versionmodel extends CI_Model {
 			and s.product_id = $productId and
 			 p.product_id = s.product_id 
 			 and p.product_active=1 
-			and p.channel_active=1 
+			 and p.channel_active=1
+			 and s.session >0
 			and p.version_active=1 
 			and p.version_name=s.version_name
 			 group by p.version_name) t
-			  right join 
+			  left join 
 			( select distinct pp.version_name
 			 from ".$dwdb->dbprefix('dim_product')." pp 
 			where pp.product_id = $productId


### PR DESCRIPTION
When there are more than 14 version in the version report , some version's data will be covered on the chart. So I pick the most 10 versions in the duration and filter others (you can change the sql as your wish) version most of which's data is empty.
