### PR TITLE
fix some bugs

### DIFF
--- a/web/application/libraries/phpass-0.1/PasswordHash.php
+++ b/web/application/libraries/phpass-0.1/PasswordHash.php
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 

--- a/web/assets/sql/dbtables.sql
+++ b/web/assets/sql/dbtables.sql
@@ -216,7 +216,7 @@ CREATE TABLE IF NOT EXISTS `umsinstall_errorlog` (
   `session_id` varchar(32) DEFAULT NULL,
   `useridentifier` varchar(32) DEFAULT NULL,
   `lib_version` varchar(16) DEFAULT NULL,
-  `deviceid` varchar(32) DEFAULT NULL,
+  `deviceid` varchar(128) DEFAULT NULL,
   `dsymid` varchar(64) DEFAULT NULL,
   `cpt` varchar(64) DEFAULT NULL,
   `bim` varchar(64) DEFAULT NULL,
@@ -814,7 +814,7 @@ CREATE TABLE IF NOT EXISTS `umsinstall_getui_product` (
 
 CREATE TABLE IF NOT EXISTS `umsinstall_device_tag` (
     `id` int(11) NOT NULL AUTO_INCREMENT,
-    `deviceid` varchar(256) NOT NULL,
+    `deviceid` varchar(128) NOT NULL,
     `tags` varchar(1024) default NULL,
     `appkey` varchar(64) NOT NULL,
     `useridentifier` varchar(32) DEFAULT NULL,

--- a/web/assets/sql/dwtables.sql
+++ b/web/assets/sql/dwtables.sql
@@ -322,7 +322,7 @@ CREATE TABLE IF NOT EXISTS `umsinstall_fact_event` (
   `event_sk` int(11) NOT NULL,
   `product_sk` int(11) NOT NULL,
   `date_sk` int(11) NOT NULL,
-  `deviceid` varchar(50) DEFAULT NULL,
+  `deviceid` varchar(128) DEFAULT NULL,
   `category` varchar(50) DEFAULT NULL,
   `event` varchar(50) NOT NULL,
   `label` varchar(50) DEFAULT NULL,

--- a/web/system/core/Config.php
+++ b/web/system/core/Config.php
@@ -71,7 +71,7 @@ class CI_Config {
 			// It's not exhaustive, only checks for valid characters.
 			if (isset($_SERVER['HTTP_HOST']) && preg_match('/^((\[[0-9a-f:]+\])|(\d{1,3}(\.\d{1,3}){3})|[a-z0-9\-\.]+)(:\d+)?$/i', $_SERVER['HTTP_HOST']))
 			{
-				$base_url = (empty($_SERVER['HTTPS']) OR strtolower($_SERVER['HTTPS']) === 'off') ? 'http' : 'https';
+				$base_url = $this->is_https() ? 'https' : 'http';
 				$base_url .= '://'. $_SERVER['HTTP_HOST'];
 				$base_url .= substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], basename($_SERVER['SCRIPT_FILENAME'])));
 			}
@@ -84,6 +84,17 @@ class CI_Config {
 			$this->set_item('base_url', $base_url);
 		}
 	}
+
+    function is_https() {
+        if (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') {
+            return true;
+        } elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+            return true;
+        } elseif (!empty($_SERVER['HTTP_FRONT_END_HTTPS']) && strtolower($_SERVER['HTTP_FRONT_END_HTTPS']) !== 'off') {
+            return true;
+        }
+        return false;
+    }
 
 	// --------------------------------------------------------------------
 


### PR DESCRIPTION
1. Construct method same name with class is deprecated, use __construct. In file `web/application/libraries/phpass-0.1/PasswordHash.php`
2. In some situation, http/https judgement not work, fixed. In file `web/system/core/Config.php`
3. Unified `deviceid` length 128 for all table